### PR TITLE
Updating build.cmd to fix errors on Windows

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
-tools/paket.bootstrapper.exe
-tools/paket.exe install
-msbuild src/Web.sln
+tools\paket.bootstrapper.exe
+tools\paket.exe install
+msbuild src\Web.sln

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,4 @@
 tools\paket.bootstrapper.exe
 tools\paket.exe install
+path=%path%;%windir%\Microsoft.net\Framework\v4.0.30319
 msbuild src\Web.sln


### PR DESCRIPTION
Convert to back slash to be able to run on Windows 
Adding PATH to be able to find msbuild
There are still a lot of errors after that, but I think it's not a big deal and may be msbuild part maybe can be removed ?
